### PR TITLE
Bugfix: evaluate pixel height as integers to avoid browser-specific s…

### DIFF
--- a/responsiveTruncator.js
+++ b/responsiveTruncator.js
@@ -45,7 +45,7 @@
 						toggle_link.click(function(){
 						  var text = toggle_link.text() == settings.more ? settings.less : settings.more;
 							toggle_link.text(text);
-							if(truncate.height() == truncate_height){
+							if(parseInt(truncate.height(), 10) <= parseInt(truncate_height), 10) {
 								truncate.css({height: '100%'})
 							}else{
 								truncate.css({height: truncate_height})


### PR DESCRIPTION
…ubpixel calculation differences.

See https://github.com/projectblacklight/arclight/issues/1027 for examples where Firefox would evaluate
truncate.height() as 61.2, truncate_height as 61.1999... and thus not expand.

Also noting that the original `==` comparison operator in the line in question was changed to `<=` in ArcLight in this Oct 3, 2019 commit:
https://github.com/projectblacklight/arclight/commit/406379f16ad6dadd650eae159a37d44be10f6d58
